### PR TITLE
Add initial repository structure and documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,178 @@
+# CLAUDE.md - LFX Engineering Repository Guide
+
+## Project Overview
+
+This repository serves as a centralized collection of engineering artifacts,
+documentation, and configuration guides for The Linux Foundation's engineering
+team. It focuses on AI tool integration, team onboarding, and best practices for
+development workflows.
+
+## Repository Structure
+
+```code
+lfx-engineering/
+├── README.md                 # Basic repository description
+├── MAINTAINERS.md           # Team maintainers and contact information
+├── LICENSE                  # MIT License for software components
+├── LICENSE-docs            # Creative Commons Attribution 4.0 for documentation
+├── .gitignore              # Excludes .claude/ directory
+├── mcp/                    # Model Context Protocol configurations
+│   └── jira.md            # Jira MCP setup guide for AI tools
+├── onboarding/             # Team onboarding resources
+│   └── cursor.md          # Cursor AI setup and workspace invitation
+├── expectations/           # (Currently empty) Expected to contain team expectations
+├── prompts/               # (Currently empty) Expected to contain AI prompts
+└── training/              # (Currently empty) Expected to contain training materials
+```
+
+## Technology Stack
+
+- **Repository Type**: Documentation and configuration repository
+- **Primary Focus**: AI tooling integration and team resources
+- **Licensing**: Dual licensing approach
+  - MIT License for software components
+  - Creative Commons Attribution 4.0 for documentation
+- **Version Control**: Git with main branch as primary
+
+## Key Components
+
+### 1. AI Tool Integration
+
+- **Jira MCP Configuration**: Comprehensive setup guide for integrating Jira with AI tools
+  - Claude Code (CLI) configuration with API tokens
+  - Cursor AI integration with MCP servers
+  - Atlassian authorization workflows
+  - Validation and testing procedures
+
+### 2. Team Onboarding
+
+- **Cursor AI Setup**: Instructions for team members to join the LF AI workspace
+- **Tool Access**: Process for requesting invites through #lf-ai Slack channel
+
+### 3. Team Management
+
+- **Maintainers**: Four primary maintainers from The Linux Foundation (see [MAINTAINERS.md](MAINTAINERS.md))
+  - David Deal (dealako)
+  - Jordan Evans (jordane)
+  - Luis Guerra (luismoriguerra)
+  - Michal Lehotsky (mlehotskylf)
+
+## Development Workflow
+
+### File Management
+
+- Documentation files use Markdown format
+- Configuration examples provided in JSON format
+- Clear separation between software (MIT) and documentation (CC BY 4.0) licenses
+
+### AI Tool Configuration
+
+- MCP (Model Context Protocol) servers for external service integration
+- Support for multiple AI platforms (Claude Code, Cursor AI)
+- Standardized configuration patterns across tools
+
+## Key Features
+
+### Jira Integration
+
+- Complete MCP setup for Jira API access
+- Support for both individual and team configurations
+- Validation procedures with example queries
+- Security considerations with API token management
+
+### Team Collaboration
+
+- Centralized workspace management for Cursor AI
+- Slack-based invitation process (#lf-ai channel)
+- Standardized onboarding procedures
+
+## Usage Patterns
+
+### For New Team Members
+
+1. Review onboarding documentation in `/onboarding/`
+2. Request Cursor AI workspace access via #lf-ai Slack channel
+3. Follow MCP setup guides for tool integration
+4. Configure personal API tokens as needed
+
+### For AI Tool Setup
+
+1. Reference `/mcp/jira.md` for Jira integration
+2. Follow platform-specific configuration (Claude Code vs Cursor AI)
+3. Complete authorization workflows
+4. Validate setup with provided test procedures
+
+### For Documentation Updates
+
+1. Maintain dual licensing approach
+2. Use Markdown for all documentation
+3. Follow existing structure and formatting patterns
+4. Consider both software and documentation licensing requirements
+
+## Security Considerations
+
+- API tokens should be stored securely (password managers recommended)
+- Many MCP configurations require proper authorization workflows
+- Git ignores `.claude/` directory for local configurations, command approvals, etc.
+
+## Future Development
+
+Based on the directory structure, planned expansions likely include:
+
+- **Expectations**: Team standards and development expectations
+- **Prompts**: Standardized AI prompts for common tasks
+- **Training**: Educational materials and best practices
+
+## Best Practices
+
+1. **Documentation**: All setup procedures include validation steps
+2. **Security**: Clear guidance on secure token management
+3. **Team Coordination**: Centralized communication through dedicated Slack channels
+4. **Tool Integration**: Standardized MCP patterns across different AI platforms
+5. **Version Control**: Proper gitignore patterns for sensitive local configurations
+
+## Contact and Support
+
+For questions or access requests:
+
+- Join the #lf-ai Slack channel
+- Contact repository maintainers listed in MAINTAINERS.md
+- Follow established onboarding procedures
+
+This repository demonstrates a mature approach to AI tool integration within an
+enterprise engineering environment, with emphasis on security, standardization,
+and team collaboration.
+
+## Jira Integration
+
+When a Jira ticket is mentioned, ask the user if we should update the
+corresponding Jira ticket to indicate it is ‘In Progress’. Ask the user if a
+comment should be added to the Jira ticket after successfully completing a task
+or activity. If the user agrees, then build a progress report and submit this
+comment to the Jira ticket.
+
+When a Jira ticket is mentioned, review the Jira ticket description. If the Jira
+ticket description does not include a ‘Acceptance Criteria’ section, then prompt
+the user to add one. Each ticket should have some completion criteria.
+
+When a Jira ticket is mentioned, review the Jira ticket description. If the Jira
+ticket description does not include a ‘Reviewers/Stakeholders’ section, then
+prompt the user to add one. Each ticket should know who can validate and confirm
+that the feature was implemented or the bug fix was resolved.
+
+When a pull request is created and a Jira ticket is associated with the work,
+confirm and add the GitHub pull request to the Jira as a comment.
+
+## Git Integration
+
+For all git commits, use the `--signoff` option for DCO and the `-S` for signed
+commits. If a Jira ticket is mentioned in the prompt, ensure the Jira ticket
+identifier and link are included in the commit message.
+
+Review the git branch name. If a Jira ticket number is provided and is not
+included in the branch name, prompt and suggest to the user a better branch name
+that includes the Jira ticket identifier in the name. A bad branch name example
+is ‘feature/update-cookie-policy’. A better branch name example would be
+‘feature/LH-2-update-cookie-policy’, where the format is
+‘feature/{JIRA_TICKET_IDENTIFIER}-{feature-short-name}’ or
+‘bug/{JIRA_TICKET_IDENTIFIER}-{bug-short-name}.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,18 @@
+Copyright The Linux Foundation and each contributor to LFX.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/LICENSE-docs
+++ b/LICENSE-docs
@@ -1,0 +1,395 @@
+Attribution 4.0 International
+
+=======================================================================
+
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+    wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More considerations
+     for the public:
+    wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution 4.0 International Public License ("Public License"). To the
+extent this Public License may be interpreted as a contract, You are
+granted the Licensed Rights in consideration of Your acceptance of
+these terms and conditions, and the Licensor grants You such rights in
+consideration of benefits the Licensor receives from making the
+Licensed Material available under these terms and conditions.
+
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  d. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  e. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  f. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  g. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  h. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  i. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  j. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  k. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+       4. If You Share Adapted Material You produce, the Adapter's
+          License You apply must not prevent recipients of the Adapted
+          Material from complying with this Public License.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material; and
+
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public
+licenses. Notwithstanding, Creative Commons may elect to apply one of
+its public licenses to material it publishes and in those instances
+will be considered the “Licensor.” The text of the Creative Commons
+public licenses is dedicated to the public domain under the CC0 Public
+Domain Dedication. Except for the limited purpose of indicating that
+material is shared under a Creative Commons public license or as
+otherwise permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the
+public licenses.
+
+Creative Commons may be contacted at creativecommons.org.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,12 @@
+# Maintainers
+
+The following developers maintain this repository:
+
+
+| Organization         | Name             | GitHub Username     |
+|:---------------------|:-----------------|:--------------------|
+| The Linux Foundation | David Deal       | dealako             |
+| The Linux Foundation | Jordan Evans     | jordane             |
+| The Linux Foundation | Luis Guerra      | luismoriguerra      |
+| The Linux Foundation | Michal Lehotsky  | mlehotskylf         |
+

--- a/expectations/roles-and-responsibilities.md
+++ b/expectations/roles-and-responsibilities.md
@@ -1,0 +1,123 @@
+# Roles and Responsibilities Framework: Product Owners, Engineers, and IT/Operations
+
+## Product Owners
+
+### Product Owners Primary Responsibilities
+
+- Requirements Gathering: Collect, analyze, and prioritize business requirements from stakeholders
+- UX Design & User Interactions: Define user experience flows, wireframes, and interaction patterns
+- Success Criteria Definition: Establish measurable KPIs, acceptance criteria, and business objectives
+- Product Documentation: Maintain product specifications, user stories, and feature documentation
+
+### Product Owners Additional Responsibilities
+
+- Product Strategy & Roadmap: Define long-term product vision and quarterly/annual roadmaps
+- Stakeholder Management: Interface with business stakeholders, customers, and executive leadership
+- Competitive Analysis: Monitor market trends and competitor features
+- User Research & Feedback: Conduct user interviews, surveys, and analyze usage data
+- Feature Prioritization: Make trade-off decisions based on business value and technical constraints
+- Go-to-Market Planning: Collaborate on launch strategies and marketing requirements
+- Compliance & Legal Requirements: Ensure features meet regulatory and legal standards
+
+### Product Owners Boundaries
+
+- Does not make technical architecture decisions
+- Does not directly manage engineering resources or timelines
+- Does not configure or deploy infrastructure
+
+### Product Owners Escalation and Decision-Making Authority
+
+- Product Decisions: Product Owners have final authority on feature requirements and business priorities
+- Technical Decisions: Engineers have authority on technical implementation and architecture choices
+- Operational Decisions: IT/Operations has authority on infrastructure, deployment methods, and operational procedures
+- Cross-functional Conflicts: Escalate to management when decisions impact multiple domains
+
+## Engineers/Developers
+
+### Engineers/Developers Primary Responsibilities
+
+- End-to-End Software Development: Design, code, and implement UX, backend, and data components
+- Testing: Create and execute unit tests, integration tests, and functional tests
+- Software Security: Implement security best practices and address vulnerabilities
+- Release Documentation: Provide technical inputs for release notes and deployment guides
+- Deployment Configuration Support: Specify runtime requirements and configuration needs for IT
+
+### Engineers/Developers Additional Responsibilities
+
+- Technical Architecture: Design system architecture, APIs, and data models
+- Code Quality & Standards: Establish coding standards, conduct code reviews, and maintain technical debt
+- Performance Optimization: Ensure applications meet performance and scalability requirements
+- Technical Documentation: Create API documentation, technical specs, and architecture diagrams
+- Environment Management: Support development, staging, and testing environment needs
+- Incident Response Support: Provide technical expertise during outages and debugging
+- Technology Evaluation: Research and recommend new tools, frameworks, and technologies
+- Cross-functional Collaboration: Work with Product Owners on feasibility and IT on deployment requirements
+
+### Engineers/Developers Boundaries
+
+- Does not define business requirements or product strategy
+- Does not manage production infrastructure or CI/CD pipelines
+- Does not directly handle customer support or business stakeholder communication
+
+## IT/Operations
+
+### IT/Operations Primary Responsibilities
+
+- CI/CD Management: Configure and maintain build, test, and deployment pipelines
+- Infrastructure Provisioning: Manage cloud resources, servers, and networking components
+- Service Deployment: Execute application deployments across environments
+- Monitoring & Alerting: Implement and maintain system monitoring, logging, and alerting
+- Incident Management: Respond to outages, coordinate resolution, and conduct post-mortems
+- Service Health Reporting: Track and report on uptime, performance metrics, and SLA compliance
+
+### IT/Operations Additional Responsibilities
+
+- Infrastructure Security: Implement security controls, access management, and compliance frameworks
+- Capacity Planning: Monitor resource usage and plan for scaling requirements
+- Backup & Disaster Recovery: Maintain data backup systems and disaster recovery procedures
+- Environment Management: Provision and maintain development, staging, and production environments
+- Cost Optimization: Monitor cloud costs and optimize resource allocation
+- Vendor Management: Manage relationships with cloud providers and third-party service vendors
+- Documentation & Runbooks: Maintain operational procedures and troubleshooting guides
+- Compliance & Auditing: Ensure infrastructure meets security and regulatory requirements
+
+### IT/Operations Boundaries
+
+- Does not make product feature decisions or business requirements
+- Does not write application code or business logic
+- Does not define user experience or product functionality
+
+## Cross-Role Collaboration Points
+
+### Product Planning Phase
+
+- Product Owners define requirements and success criteria
+- Engineers provide technical feasibility and effort estimates
+- IT/Operations advise on infrastructure constraints and deployment considerations
+
+### Development Phase
+
+- Product Owners provide clarification and acceptance testing
+- Engineers develop features and coordinate deployment requirements with IT
+- IT/Operations prepare environments and deployment configurations
+
+### Release Phase
+
+- Product Owners coordinate go-to-market activities and communicate with stakeholders
+- Engineers support deployment activities and provide technical guidance
+- IT/Operations execute deployments and monitor system health
+
+### Post-Release Phase
+
+- Product Owners gather user feedback and measure success metrics
+- Engineers address bugs and performance issues
+- IT/Operations monitor system performance and manage operational concerns
+
+## Summary of Escalation and Decision-Making Authority
+
+### Product Decisions
+
+- Product Decisions: Product Owners have final authority on feature requirements and business priorities
+- Technical Decisions: Engineers have authority on technical implementation and architecture choices
+- Operational Decisions: IT/Operations has authority on infrastructure, deployment methods, and operational procedures
+- Cross-functional Conflicts: Escalate to management when decisions impact multiple domains

--- a/mcp/jira.md
+++ b/mcp/jira.md
@@ -1,0 +1,106 @@
+# Jira MCP Configuration
+
+The following guide illustrates how to set up and configure the Jira Model Context Protocol (MCP) for various AI tools.
+
+## Claude Code Jira MCP Setup
+
+To setup a Jira MCP for Claude Code (or commonly called Claude CLI), a MCP
+configuration entry should be added to the Claude `mcpServers` configuration
+section of the `~/.claude.json` file. Once added, Claude Code must be restarted
+on the command line. The user must authorize the connection the first time the
+MCP connection is used.
+
+The MCP set up in the `~/.claude.json` file for the LF Atlassian Jira instance
+would look like:
+
+```json
+{
+  ...
+  "mcpServers": {
+    "mcp-atlassian": {
+      "type": "sse",
+      "url": "https://mcp.atlassian.com/v1/sse"
+    }
+  }
+}
+```
+
+### Atlassian Authorization
+
+Once the configuration is complete, relaunch Claude Code by running `claude` in
+a terminal window. When the MCP initializes for the first time, it will prompt
+you to click on a link to authorize the configuration. This will take you to an
+Atlassian configuration page. Ensure the ‘linuxfoundation’ instance is selected,
+review the permissions, and approve it. Once approved, the MCP should be
+accessible.
+
+### Validation
+
+To validate the setup, start Claude Code and issue the `/mcp` command. This
+should return details of the configured MCP servers.
+
+Additionally, you can generate a prompt to inquire about a specific Jira ticket.
+The AI should query Jira and return a valid response. An example prompt might
+be:
+
+```text
+What is the current status of the Jira ticket number: ME-36?
+```
+
+Claude Code may ask for permission to make the MCP Jira request. You can approve
+it the first time or choose to approve and not ask again, allowing Claude Code
+to make the request.
+
+Example output:
+
+```code
+What is the current status of the Jira ticket: ME-36?
+
+⏺ I'll help you check the status of Jira ticket ME-36. First, let me get your Atlassian
+   cloud information and then look up the ticket.
+  ⎿  [
+       {
+         "id": "c497ae62-1596-4157-81fb-96205956683e",
+     … +26 lines (ctrl+r to expand)
+
+⏺ Now let me get the details of ticket ME-36:
+
+⏺ mcp-atlassian:getJiraIssue (MCP)(cloudId: "c497ae62-1596-4157-81fb-96205956683e",
+                                  issueIdOrKey: "ME-36")
+  ⎿ {
+      "expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRep
+    resentations,customfield_10010.requestTypePractice",
+    … +1498 lines (ctrl+r to expand)
+
+
+⏺ Status: Released
+
+  Jira ticket ME-36 is currently in Released status and has been resolved. The ticket
+  was about adding a link for next steps in RISC-V Individual Membership to ensure
+  members complete Schedule A forms. The work was completed on June 18, 2025, with the
+  solution deployed to production.
+```
+
+## Cursor AI Jira MCP Setup
+
+To configure Cursor AI to use the Jira MCP, the MCP server needs to be added to
+the global MCP configuration. Unlike Claude Code, Cursor AI does not need a
+separate API token. The authorization workflow is handled when Cursor AI is
+launched/restarted.
+
+### Cursor Global MCP Configuration
+
+Here is an example of the Cursor AI MCP configuration for the Jira MCP:
+
+Edit the `~/.cursor/mcp.json` file to add the Jira MCP server.
+
+```json
+{
+  "mcpServers": {
+    "mcp-atlassian": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "https://mcp.atlassian.com/v1/sse"]
+    }
+  }
+}
+```

--- a/onboarding/cursor.md
+++ b/onboarding/cursor.md
@@ -1,0 +1,12 @@
+# Cursor AI
+
+The LF Engineering team uses Cursor AI to support the development of software,
+IT, Operations, Marketing, BizOps, and other teams.
+
+To get started, you will need to
+[install the Cursor AI from the website](https://www.cursor.com).
+
+Once Cursor AI is installed, you should request an invite to the Cursor AI
+workspace managed by the LF Engineering team. The best way to do this is to join
+the `#lf-ai` Slack channel and ask for the invite link. Most users will sign up
+using their LF email address.


### PR DESCRIPTION
## Summary
- Establish foundational repository structure for LFX Engineering team
- Add comprehensive documentation and AI tool integration guides
- Create team onboarding processes and maintainer structure

## Changes Made
- **Repository Configuration**: Added `.gitignore` and dual licensing (MIT + CC BY 4.0)
- **Documentation**: Created comprehensive `CLAUDE.md` guide for future development
- **Team Structure**: Established `MAINTAINERS.md` with four key maintainers
- **AI Integration**: Added Jira MCP setup guides for Claude Code and Cursor AI
- **Onboarding**: Created Cursor AI workspace access documentation

## Test Plan
- [x] Verify all documentation files are properly formatted
- [x] Confirm dual licensing structure is correctly implemented
- [x] Validate MCP configuration examples are accurate
- [x] Ensure team maintainer information is current
- [x] Review CLAUDE.md provides comprehensive guidance for future instances

## Files Added
- `.gitignore` - Excludes sensitive `.claude/` directory
- `CLAUDE.md` - Repository guide for AI development
- `LICENSE` - MIT License for software components
- `LICENSE-docs` - Creative Commons Attribution 4.0 for documentation
- `MAINTAINERS.md` - Team maintainer contact information
- `mcp/jira.md` - Jira MCP integration guide
- `onboarding/cursor.md` - Team onboarding for Cursor AI

This establishes the foundation for the LFX Engineering repository as a centralized hub for engineering artifacts, documentation, and AI tooling configuration.

🤖 Generated with [Claude Code](https://claude.ai/code)