### PR TITLE
Add Zed instructions for Jira MCP

### DIFF
--- a/mcp/jira.md
+++ b/mcp/jira.md
@@ -1,6 +1,7 @@
 # Jira MCP Configuration
 
-The following guide illustrates how to set up and configure the Jira Model Context Protocol (MCP) for various AI tools.
+The following guide illustrates how to set up and configure the Jira Model
+Context Protocol (MCP) for various AI tools.
 
 ## Claude Code Jira MCP Setup
 
@@ -115,7 +116,9 @@ See the Validation section below for an example.
 
 ## Zed
 
-Zed supports agentic editing including tools. Like Cursor, it does not support SSE MCP servers natively, and needs a `stdio->sse` proxy. Use `Cmd-,` to bring up the configuration, and add the following:
+Zed supports agentic editing including tools. Like Cursor, it does not support
+SSE MCP servers natively, and needs a `stdio->sse` proxy. Use `Cmd-,` to bring
+up the configuration, and add the following:
 
 ```jsonc
 {
@@ -130,18 +133,25 @@ Zed supports agentic editing including tools. Like Cursor, it does not support S
   }
 }
 ```
+
 ### Zed validation
 
-The agent panel settings show the status of each enabled MCP server (green or red). If the Jira MCP times out, this has been connected to an issue where global `npx` invocations of `mcp-remote` fail on missing dependencies (e.g. `iconv-lite`) both when run via the CLI or in Zed. For a workaround, install mcp-remote globally:
+The agent panel settings show the status of each enabled MCP server (green or
+red). If the Jira MCP times out, this has been connected to an issue where
+global `npx` invocations of `mcp-remote` fail on missing dependencies (e.g.
+`iconv-lite`) both when run via the CLI or in Zed. For a workaround, install
+mcp-remote globally:
 
 ```bash
 npm i -g mcp-remote
 which mcp-remote
 ```
 
-If `which` does not return the location of mcp-remote, ensure that the global Node `bin` folder is in your `PATH`.
+If `which` does not return the location of mcp-remote, ensure that the global
+Node `bin` folder is in your `PATH`.
 
-Then, modify the Zed MCP command and args to use the globally-installed `mcp-remote`:
+Then, modify the Zed MCP command and args to use the globally-installed
+`mcp-remote`:
 
 ```jsonc
     "mcp-atlassian": {


### PR DESCRIPTION
This pull request updates the `mcp/jira.md` documentation to improve clarity and add new configuration details for Zed. The most important changes include switching code block formatting to `jsonc` for better readability and adding a new section on configuring and validating Zed for MCP connections.

### Documentation improvements for MCP configuration:

* Updated code block formatting from `json` to `jsonc` to allow for comments, improving clarity in configuration examples. (`[[1]](diffhunk://#diff-c0acc0c9e3f47322bf5ff00d808f3966cda5e8a25d220d02e68b96d73e81550cL16-R18)`, `[[2]](diffhunk://#diff-c0acc0c9e3f47322bf5ff00d808f3966cda5e8a25d220d02e68b96d73e81550cL79-R81)`)

### New Zed configuration details:

* Added a new section on configuring Zed to support MCP connections using a `stdio->sse` proxy, including example configuration and troubleshooting steps. (`[mcp/jira.mdR116-R154](diffhunk://#diff-c0acc0c9e3f47322bf5ff00d808f3966cda5e8a25d220d02e68b96d73e81550cR116-R154)`)
* Provided a workaround for Zed MCP connection issues by installing `mcp-remote` globally and modifying the configuration to use the globally-installed version. (`[mcp/jira.mdR116-R154](diffhunk://#diff-c0acc0c9e3f47322bf5ff00d808f3966cda5e8a25d220d02e68b96d73e81550cR116-R154)`)