### PR TITLE
docs: Add recorded training videos documentation

### DIFF
--- a/training/recorded-training-videos.md
+++ b/training/recorded-training-videos.md
@@ -1,0 +1,26 @@
+# Recorded Training Videos
+
+## n8n Workflow Automation Training
+
+Michal Lehotsky coordinated a training session for the EasyCLA and Mentorship
+teams on n8n's workflow automation technology. The training session was held on
+Monday, July 28, 2025. The video is available [via this Zoom
+recording](https://zoom.us/rec/share/eRoWa6hZchWb1WSFK5uTI33GvAP7SONmkMFytQeoEErJSI5YIkvesE2ySdP_EdnG.eyUkV3Xpq1_4j49L?startTime=1753713178000).
+
+More information on n8n can be found [on their product website](https://n8n.io/).
+
+## Playwright Training
+
+On Wednesday, July 30, 2025, Asitha de Silva recorded [a 12-minute
+video](https://drive.google.com/file/d/1l6y7YjMxBFujsL1zuk96a0q8fpcVQdR5/view)
+showcasing how to use the Playwright MCP to generate and run functional tests
+for the LF Projects POC product.
+
+Michal Lehotsky and the EasyCLA and Mentorship team members held a second "AI
+Tools" session on Thursday, July 31, 2025. Ahmed Omosanya presented Playwright
+MCP. [Here is 30 minute recording with demo if somebody is
+interested](https://zoom.us/rec/share/r6UvEKR8fPHEg2VLviXkhY0fxsORr2jM_xK-vFAiEs7LUAyxBbMw53RX531qGd4_.rxy99jfPePv1syUM?startTime=1753972303000).
+
+More information on Playwright can be found [on their product
+website](https://playwright.dev/) or [their general documentation
+page](https://playwright.dev/docs/intro).


### PR DESCRIPTION
## Summary
- Added documentation for recorded training videos in the training directory
- Documented n8n workflow automation training from July 28, 2025
- Documented Playwright MCP training sessions from July 30 & 31, 2025

## Details
This PR adds a new documentation file (`training/recorded-training-videos.md`) that catalogs important training sessions conducted for the team:

1. **n8n Workflow Automation Training** - Coordinated by Michal Lehotsky for EasyCLA and Mentorship teams
2. **Playwright MCP Training** - Two sessions featuring demos by Asitha de Silva and Ahmed Omosanya

These resources will help team members access training materials for workflow automation and functional testing tools used in LF projects.

## Test plan
- [x] Documentation file renders correctly in Markdown
- [x] All links are properly formatted
- [x] Content follows repository documentation standards

🤖 Generated with [Claude Code](https://claude.ai/code)